### PR TITLE
style spiff ups for closing comment

### DIFF
--- a/pages/euclid-condor.njk
+++ b/pages/euclid-condor.njk
@@ -8,7 +8,6 @@ translated: false
 
 <div class="program-description mobile-switch-grid">
   <div class="program-description-header top-left">
-    <span class="program-identifier"><span class="emphasis-circle"></span>Public comment open</span>
     <h1>Euclid Condor Retail Center cleanup</h1>
   </div>
   <div class="program-map middle-right">
@@ -17,13 +16,5 @@ translated: false
   </div>
   <div class="program-description-content bottom-left">
     <p>Public comment for the proposed cleanup plan at the Euclid Condor Retail Center has ended. You can get the latest updates about the project on <a href="https://www.envirostor.dtsc.ca.gov/public/profile_report?global_id=60002975">EnviroStor</a>. Select the Site/Facility Docs tab to find all documents about this project. You may need to scroll right to see it.</p>
-
-    <p class="icon-left">
-      <span class="icon-container">
-        <svg class="icon-item" width="16" height="17" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M22.9359 0.865955C22.6482 0.332301 22.0916 0 21.486 0H1.64703C0.737917 0 0 0.736481 0 1.64703V23.353C0 24.2621 0.736481 25 1.64703 25C2.55614 25 3.29406 24.2635 3.29406 23.353V16.2816H21.4859C22.0915 16.2816 22.6481 15.9494 22.9358 15.4157C23.2235 14.882 23.1947 14.2347 22.861 13.7284L19.1772 8.13999L22.861 2.55305C23.1933 2.04815 23.2235 1.39943 22.9358 0.865771L22.9359 0.865955Z" fill="#046B99"/>
-        </svg>
-      </span>
-    </p>
   </div>
 </div>


### PR DESCRIPTION
I removed:
- the lone flag icon
- the public comment open notification at the top

The spacing on desktop is there because the left side has to match the map height. I don't think it is worth it to modify those styles for the closing state. 

Should we remove the map?